### PR TITLE
avoid duplicating config from 'plugin:jest/recommended'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 module.exports = {
   parser: 'babel-eslint',
-  plugins: ['jest'],
   extends: [
     'airbnb-base',
     'plugin:jest/recommended',
@@ -8,7 +7,6 @@ module.exports = {
   ],
   env: {
     node: true,
-    'jest/globals': true,
   },
   rules: {
     // not worth fixing all these IMO


### PR DESCRIPTION
I noticed a possible simplification of the config: the `eslint-plugin-jest` recommended config that we are already extending [already defines these Jest-specific options](https://github.com/jest-community/eslint-plugin-jest/blob/v23.8.2/src/index.ts#L41), so we don't need to specify them explicitly.