### PR TITLE
add custom devDep pattern for import/no-extraneous-dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,28 @@ module.exports = {
 
     // Allow underscore dangles for private members (e.g. this._foo)
     'no-underscore-dangle': ['error', { allowAfterThis: true }],
+
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: [
+          // Custom patterns for "dev only" files in our code
+          '.storybook/**', // Storybook
+          'stories/**', // Storybook
+          '**/setupTests.js', // CRA Jest setup
+          '**/*.config.js', // Config files
+          // The rest of these are copied from eslint-config-airbnb-base:
+          // https://github.com/airbnb/javascript/blob/0375265cbd43635f8062615995a6a86f22fd0fc2/packages/eslint-config-airbnb-base/rules/imports.js#L71
+          'test/**',
+          'tests/**',
+          '**/__tests__/**',
+          '**/__mocks__/**',
+          'test.{js,jsx}',
+          'test-*.{js,jsx}',
+          '**/*{.,_}{test,spec}.{js,jsx}',
+        ],
+        optionalDependencies: false,
+      },
+    ],
   },
 };


### PR DESCRIPTION
`import/no-extraneous-dependencies` is an ESLint rule that is intended to ensure that you don't import libraries installed as `devDependencies` from inside non-dev code. It needs to be configured with glob patterns to let it know which files should be considered "dev-only".

Several of our projects have had to set up custom overrides of the this rule because the default config (configured in `eslint-config-airbnb-base`) was not aware of these dev-only files. This is an attempt to centralize those exceptions so that each project doesn't have to roll their own. Specifically, I am adding:
- `'.storybook/**'` and `'stories/**'` (Storybook files used in Linoleum)
- `**/setupTests.js` (Create React App test setup file, used in web apps)
- `**/*.config.js` (misc. config files used throughout our apps, including Webpack, Rollup, Babel, ESLint, postcss, etc.)

Since we are overriding the rule definition from `eslint-config-airbnb-base`, I also needed to copy [the test file patterns we use from their rule set](https://github.com/airbnb/javascript/blob/0375265cbd43635f8062615995a6a86f22fd0fc2/packages/eslint-config-airbnb-base/rules/imports.js#L71).