### PR TITLE
fix: update prettier; also update peerdep

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,3 @@
 {
-  "trailingComma": "es5",
   "singleQuote": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,6 +309,7 @@
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-8.3.4.tgz",
       "integrity": "sha512-B4MylKvT02UE3VHC5098OHxsrgkADUy5AD4Cdkiy7oX/edWypEmvK7Wuns3B9dwluWP/iFM6daoWtpkCVZoRwQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@commitlint/execute-rule": "^8.3.4",
         "@commitlint/resolve-extends": "^8.3.4",
@@ -324,6 +325,7 @@
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
           "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "import-fresh": "^2.0.0",
             "is-directory": "^0.3.1",
@@ -336,6 +338,7 @@
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
           "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "caller-path": "^2.0.0",
             "resolve-from": "^3.0.0"
@@ -345,7 +348,8 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
               "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -354,6 +358,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
+          "optional": true,
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -363,7 +368,8 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -413,6 +419,7 @@
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-8.3.4.tgz",
       "integrity": "sha512-M34RLaAW1eGWgtkVtotHfPaJa+cZIARe8twKItd7RhWs7n/1W2py9GTFIiIEq95LBN1uah5vm1WQHsfLqPZYHA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/node": "^12.0.2",
         "import-fresh": "^3.0.0",
@@ -425,13 +432,15 @@
           "version": "12.12.24",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.24.tgz",
           "integrity": "sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8844,9 +8853,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "eslint": "^6.8.0",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",
@@ -50,7 +50,7 @@
     "eslint": "^6.8.0",
     "husky": "^4.2.3",
     "lint-staged": "^10.1.1",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.4",
     "semantic-release": "^17.0.4"
   },
   "publishConfig": {


### PR DESCRIPTION
Updates the local version of prettier, and also updates the peerDep to remove warnings in consumers who've upgraded.