### PR TITLE
Revert "build: produce releases when non-dev dependencies are updated"

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,12 +1,7 @@
 module.exports = {
   preset: 'conventionalcommits',
   plugins: [
-    [
-      '@semantic-release/commit-analyzer',
-      {
-        releaseRules: [{ type: 'build', scope: 'deps', release: 'minor' }],
-      },
-    ],
+    '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     '@semantic-release/npm',


### PR DESCRIPTION
It turns out that getting `@semantic-release/release-notes-generator` to generate release notes that include `build`-tagged commits seems to be hard/impossible (the [config for which types of commits are omitted from release notes](https://github.com/conventional-changelog/conventional-changelog/blob/7a217137ba71caba965e194bae2fe774fe96b2e7/packages/conventional-changelog-conventionalcommits/writer-opts.js#L162) does not seem easily customizable from the plugin's options).

Going to use a different approach instead: [configuring dependabot to use different commit messages](https://dependabot.com/docs/config-file/#commit_message) for updates to non-dev dependencies.