### PR TITLE
configure Dependabot to use 'fix' prefix for non-development dependency updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,3 +5,7 @@ update_configs:
     update_schedule: "monthly"
     default_reviewers:
       - "gavinsharp"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true


### PR DESCRIPTION
See #39 and #38. The goal of this change is to ensure that releases are generated by  our `semantic-release` setup when non-development dependencies are updated.