### PR TITLE
force update sub-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -805,34 +805,50 @@
       }
     },
     "@octokit/endpoint": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.3.tgz",
-      "integrity": "sha512-Y900+r0gIz+cWp6ytnkibbD95ucEzDSKzlEnaWS52hbCDNcCJYO5mRmWW7HRAnDc7am+N/5Lnd8MppSaTYx1Yg==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.6.tgz",
+      "integrity": "sha512-7Cc8olaCoL/mtquB7j/HTbPM+sY6Ebr4k2X2y4JoXpVKQ7r5xB4iGQE0IoO58wIPsUk4AzoT65AMEpymSbWTgQ==",
       "dev": true,
       "requires": {
         "@octokit/types": "^5.0.0",
-        "is-plain-object": "^3.0.0",
-        "universal-user-agent": "^5.0.0"
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "universal-user-agent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+          "dev": true
+        }
       }
     },
     "@octokit/graphql": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.1.tgz",
-      "integrity": "sha512-qgMsROG9K2KxDs12CO3bySJaYoUu2aic90qpFrv7A8sEBzZ7UFGvdgPKiLw5gOPYEYbS0Xf8Tvf84tJutHPulQ==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.6.tgz",
+      "integrity": "sha512-Rry+unqKTa3svswT2ZAuqenpLrzJd+JTv89LTeVa5UM/5OX8o4KTkPL7/1ABq4f/ZkELb0XEK/2IEoYwykcLXg==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^5.0.0",
-        "universal-user-agent": "^5.0.0"
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "universal-user-agent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+          "dev": true
+        }
       }
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.3.tgz",
-      "integrity": "sha512-eKTs91wXnJH8Yicwa30jz6DF50kAh7vkcqCQ9D7/tvBAP5KKkg6I2nNof8Mp/65G0Arjsb4QcOJcIEQY+rK1Rg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.4.0.tgz",
+      "integrity": "sha512-YT6Klz3LLH6/nNgi0pheJnUmTFW4kVnxGft+v8Itc41IIcjl7y1C8TatmKQBbCSuTSNFXO5pCENnqg6sjwpJhg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^5.0.0"
+        "@octokit/types": "^5.5.0"
       }
     },
     "@octokit/plugin-request-log": {
@@ -863,19 +879,27 @@
       }
     },
     "@octokit/request": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.5.tgz",
-      "integrity": "sha512-atAs5GAGbZedvJXXdjtKljin+e2SltEs48B3naJjqWupYl2IUBbB/CJisyjbNHcKpHzb3E+OYEZ46G8eakXgQg==",
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
+      "integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
         "@octokit/types": "^5.0.0",
         "deprecation": "^2.0.0",
-        "is-plain-object": "^3.0.0",
-        "node-fetch": "^2.3.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "once": "^1.4.0",
-        "universal-user-agent": "^5.0.0"
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "universal-user-agent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+          "dev": true
+        }
       }
     },
     "@octokit/request-error": {
@@ -902,9 +926,9 @@
       }
     },
     "@octokit/types": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.1.tgz",
-      "integrity": "sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+      "integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
@@ -1009,9 +1033,9 @@
       }
     },
     "@semantic-release/github": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.0.7.tgz",
-      "integrity": "sha512-Sai2UucYQ+5rJzKVEVJ4eiZNDdoo0/CzfpValBdeU5h97uJE7t4CoBTmUWkiXlPOx46CSw1+JhI+PHC1PUxVZw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.1.1.tgz",
+      "integrity": "sha512-w8CLCvGVKNe2FPOYQ68OFxFVNNha7YRzptnwTZYdjXYtgTDKw0XVfnMSd9NlJeQPYGfQmIhIVPNBU/cA6zUY0A==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^17.0.0",
@@ -1063,9 +1087,9 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.0.5.tgz",
-      "integrity": "sha512-D+oEmsx9aHE1q806NFQwSC9KdBO8ri/VO99eEz0wWbX2jyLqVyWr7t0IjKC8aSnkkQswg/4KN/ZjfF6iz1XOpw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.0.6.tgz",
+      "integrity": "sha512-F4judxdeLe8f7+vDva1TkqNc5Tb2tcltZYW0tLtvP2Xt7CD/gGiz7UxAWEOPsXBvIqAP+uTidvGLPl9U3/uRoQ==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.2.0",
@@ -1075,7 +1099,7 @@
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^5.0.0",
-        "npm": "^6.10.3",
+        "npm": "^6.13.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",
@@ -1106,14 +1130,14 @@
           }
         },
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -1128,12 +1152,6 @@
             "parse-json": "^5.0.0",
             "type-fest": "^0.6.0"
           }
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
         },
         "type-fest": {
           "version": "0.6.0",
@@ -1211,14 +1229,14 @@
           "dev": true
         },
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -1290,9 +1308,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
+      "version": "14.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.2.tgz",
+      "integrity": "sha512-IzMhbDYCpv26pC2wboJ4MMOa9GKtjplXfcAqrMeNJpUUwpM/2ATt2w1JPUXwS6spu856TvKZL2AOmeU2rAxskw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1401,9 +1419,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
       "dev": true,
       "requires": {
         "debug": "4"
@@ -1982,16 +2000,6 @@
         }
       }
     },
-    "compare-func": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-      "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-      "dev": true,
-      "requires": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^3.0.0"
-      }
-    },
     "compare-versions": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
@@ -2020,13 +2028,40 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
     },
     "conventional-changelog-angular": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.10.tgz",
-      "integrity": "sha512-k7RPPRs0vp8+BtPsM9uDxRl6KcgqtCJmzRD1wRtgqmhQ96g8ifBGo9O/TZBG23jqlXS/rg8BKRDELxfnQQGiaA==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz",
+      "integrity": "sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
+        "compare-func": "^2.0.0",
         "q": "^1.5.1"
+      },
+      "dependencies": {
+        "compare-func": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+          "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+          "dev": true,
+          "requires": {
+            "array-ify": "^1.0.0",
+            "dot-prop": "^5.1.0"
+          }
+        },
+        "dot-prop": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+          "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+          "dev": true
+        }
       }
     },
     "conventional-changelog-conventionalcommits": {
@@ -2068,12 +2103,12 @@
       }
     },
     "conventional-changelog-writer": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.16.tgz",
-      "integrity": "sha512-jmU1sDJDZpm/dkuFxBeRXvyNcJQeKhGtVcFFkwTphUAzyYWcwz2j36Wcv+Mv2hU3tpvLMkysOPXJTLO55AUrYQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
+      "integrity": "sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
+        "compare-func": "^2.0.0",
         "conventional-commits-filter": "^2.0.6",
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.6",
@@ -2085,16 +2120,10 @@
         "through2": "^3.0.0"
       },
       "dependencies": {
-        "arrify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-          "dev": true
-        },
         "camelcase": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
         "camelcase-keys": {
@@ -2106,14 +2135,25 @@
             "camelcase": "^5.3.1",
             "map-obj": "^4.0.0",
             "quick-lru": "^4.0.1"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
-            }
+          }
+        },
+        "compare-func": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+          "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+          "dev": true,
+          "requires": {
+            "array-ify": "^1.0.0",
+            "dot-prop": "^5.1.0"
+          }
+        },
+        "dot-prop": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+          "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^2.0.0"
           }
         },
         "find-up": {
@@ -2125,6 +2165,12 @@
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
+        },
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
@@ -2142,18 +2188,16 @@
           "dev": true
         },
         "meow": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
-          "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+          "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
           "dev": true,
           "requires": {
             "@types/minimist": "^1.2.0",
-            "arrify": "^2.0.1",
-            "camelcase": "^6.0.0",
             "camelcase-keys": "^6.2.2",
             "decamelize-keys": "^1.1.0",
             "hard-rejection": "^2.1.0",
-            "minimist-options": "^4.0.2",
+            "minimist-options": "4.1.0",
             "normalize-package-data": "^2.5.0",
             "read-pkg-up": "^7.0.1",
             "redent": "^3.0.0",
@@ -2171,14 +2215,6 @@
             "arrify": "^1.0.1",
             "is-plain-obj": "^1.1.0",
             "kind-of": "^6.0.3"
-          },
-          "dependencies": {
-            "arrify": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-              "dev": true
-            }
           }
         },
         "p-limit": {
@@ -2206,14 +2242,14 @@
           "dev": true
         },
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -2278,6 +2314,12 @@
             "strip-indent": "^3.0.0"
           }
         },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
         "strip-indent": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -2307,14 +2349,6 @@
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
-            }
           }
         }
       }
@@ -2586,15 +2620,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "dot-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-      "dev": true,
-      "requires": {
-        "is-obj": "^1.0.0"
       }
     },
     "duplexer2": {
@@ -3048,9 +3073,9 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "execa": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
-      "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+      "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.0",
@@ -3281,9 +3306,9 @@
       }
     },
     "figures": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-      "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -3910,12 +3935,6 @@
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4519,9 +4538,9 @@
       "dev": true
     },
     "is-plain-object": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
-      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true
     },
     "is-regex": {
@@ -5157,18 +5176,18 @@
       }
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "requires": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
       }
     },
     "macos-release": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.0.tgz",
-      "integrity": "sha512-ko6deozZYiAkqa/0gmcsz+p4jSy3gY7/ZsCEokPaYd8k+6/aXGkiTgr61+Owup7Sf+xjqW8u2ElhoM9SEcEfuA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
+      "integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
       "dev": true
     },
     "map-cache": {
@@ -5193,9 +5212,9 @@
       }
     },
     "marked": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.0.tgz",
-      "integrity": "sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
+      "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==",
       "dev": true
     },
     "marked-terminal": {
@@ -5212,15 +5231,6 @@
         "supports-hyperlinks": "^2.1.0"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.11.0"
-          }
-        },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -5263,19 +5273,13 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "type-fest": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
         }
       }
     },
@@ -5506,9 +5510,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "nerf-dart": {
@@ -5563,15 +5567,15 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.0.0.tgz",
-      "integrity": "sha512-bAEm2fx8Dq/a35Z6PIRkkBBJvR56BbEJvhpNtvCZ4W9FyORSna77fn+xtYFjqk5JpBS+fMnAOG/wFgkQBmB7hw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.1.0.tgz",
+      "integrity": "sha512-UxHuSWsSAmzSqN+DSjasaZWQ3QPtEisHdlr4y9MJ5zg0RcImv5fQt8QM0izJSCdsdmhJGK+ubcTpJXwVDmwSVQ==",
       "dev": true
     },
     "npm": {
-      "version": "6.14.7",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.7.tgz",
-      "integrity": "sha512-swhsdpNpyXg4GbM6LpOQ6qaloQuIKizZ+Zh6JPXJQc59ka49100Js0WvZx594iaKSoFgkFq2s8uXFHS3/Xy2WQ==",
+      "version": "6.14.8",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.8.tgz",
+      "integrity": "sha512-HBZVBMYs5blsj94GTeQZel7s9odVuuSUHy1+AlZh7rPVux1os2ashvEGLy/STNK7vUjbrCg5Kq9/GXisJgdf6A==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
@@ -5638,7 +5642,7 @@
         "lodash.uniq": "~4.5.0",
         "lodash.without": "~4.4.0",
         "lru-cache": "^5.1.1",
-        "meant": "~1.0.1",
+        "meant": "^1.0.2",
         "mississippi": "^3.0.0",
         "mkdirp": "^0.5.5",
         "move-concurrently": "^1.0.1",
@@ -5653,7 +5657,7 @@
         "npm-packlist": "^1.4.8",
         "npm-pick-manifest": "^3.0.2",
         "npm-profile": "^4.0.4",
-        "npm-registry-fetch": "^4.0.5",
+        "npm-registry-fetch": "^4.0.7",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
@@ -5701,7 +5705,8 @@
       "dependencies": {
         "JSONStream": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+          "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
           "dev": true,
           "requires": {
             "jsonparse": "^1.2.0",
@@ -5710,12 +5715,14 @@
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true
         },
         "agent-base": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
           "dev": true,
           "requires": {
             "es6-promisify": "^5.0.0"
@@ -5723,7 +5730,8 @@
         },
         "agentkeepalive": {
           "version": "3.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+          "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
           "dev": true,
           "requires": {
             "humanize-ms": "^1.2.1"
@@ -5731,7 +5739,8 @@
         },
         "ajv": {
           "version": "5.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
             "co": "^4.6.0",
@@ -5742,7 +5751,8 @@
         },
         "ansi-align": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "dev": true,
           "requires": {
             "string-width": "^2.0.0"
@@ -5750,12 +5760,14 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -5763,27 +5775,32 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
           "dev": true
         },
         "aproba": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -5792,7 +5809,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -5806,7 +5824,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -5816,12 +5835,14 @@
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
           "dev": true
         },
         "asn1": {
           "version": "0.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
@@ -5829,32 +5850,38 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
           "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5863,7 +5890,8 @@
         },
         "bin-links": {
           "version": "1.1.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.8.tgz",
+          "integrity": "sha512-KgmVfx+QqggqP9dA3iIc5pA4T1qEEEL+hOhOhNPaUm77OTrJoOXE/C05SJLNJe6m/2wUK7F1tDSou7n5TfCDzQ==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
@@ -5876,12 +5904,14 @@
         },
         "bluebird": {
           "version": "3.5.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
           "dev": true
         },
         "boxen": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "dev": true,
           "requires": {
             "ansi-align": "^2.0.0",
@@ -5895,7 +5925,8 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -5904,27 +5935,32 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+          "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
           "dev": true
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
           "dev": true
         },
         "byline": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+          "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
           "dev": true
         },
         "byte-size": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
+          "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
           "dev": true
         },
         "cacache": {
           "version": "12.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.5",
@@ -5946,27 +5982,32 @@
         },
         "call-limit": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.1.tgz",
+          "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -5976,17 +6017,20 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "dev": true
         },
         "ci-info": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "dev": true
         },
         "cidr-regex": {
           "version": "2.0.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.10.tgz",
+          "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
           "dev": true,
           "requires": {
             "ip-regex": "^2.1.0"
@@ -5994,12 +6038,14 @@
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "dev": true
         },
         "cli-columns": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
+          "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
           "dev": true,
           "requires": {
             "string-width": "^2.0.0",
@@ -6008,7 +6054,8 @@
         },
         "cli-table3": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+          "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
           "dev": true,
           "requires": {
             "colors": "^1.1.2",
@@ -6018,7 +6065,8 @@
         },
         "cliui": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
             "string-width": "^3.1.0",
@@ -6028,17 +6076,20 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "string-width": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "dev": true,
               "requires": {
                 "emoji-regex": "^7.0.1",
@@ -6048,7 +6099,8 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
@@ -6058,12 +6110,14 @@
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
           "dev": true
         },
         "cmd-shim": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-3.0.3.tgz",
+          "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -6072,17 +6126,20 @@
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "color-convert": {
           "version": "1.9.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
           "dev": true,
           "requires": {
             "color-name": "^1.1.1"
@@ -6090,18 +6147,21 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "colors": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
           "dev": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0",
@@ -6110,7 +6170,8 @@
         },
         "combined-stream": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -6118,12 +6179,14 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "concat-stream": {
           "version": "1.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -6134,7 +6197,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -6148,7 +6212,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -6158,7 +6223,8 @@
         },
         "config-chain": {
           "version": "1.1.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+          "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
           "dev": true,
           "requires": {
             "ini": "^1.3.4",
@@ -6166,11 +6232,12 @@
           }
         },
         "configstore": {
-          "version": "3.1.2",
-          "bundled": true,
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.5.tgz",
+          "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
           "dev": true,
           "requires": {
-            "dot-prop": "^4.1.0",
+            "dot-prop": "^4.2.1",
             "graceful-fs": "^4.1.2",
             "make-dir": "^1.0.0",
             "unique-string": "^1.0.0",
@@ -6180,12 +6247,14 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+          "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
           "dev": true,
           "requires": {
             "aproba": "^1.1.1",
@@ -6198,24 +6267,28 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             }
           }
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "create-error-class": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "dev": true,
           "requires": {
             "capture-stack-trace": "^1.0.0"
@@ -6223,7 +6296,8 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -6233,7 +6307,8 @@
           "dependencies": {
             "lru-cache": {
               "version": "4.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+              "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
               "dev": true,
               "requires": {
                 "pseudomap": "^1.0.2",
@@ -6242,24 +6317,28 @@
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
               "dev": true
             }
           }
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "dev": true
         },
         "cyclist": {
           "version": "0.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+          "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
           "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -6267,7 +6346,8 @@
         },
         "debug": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -6275,34 +6355,40 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
           "dev": true
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true
         },
         "defaults": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+          "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
           "dev": true,
           "requires": {
             "clone": "^1.0.2"
@@ -6310,7 +6396,8 @@
         },
         "define-properties": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
           "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
@@ -6318,27 +6405,32 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "dev": true
         },
         "detect-newline": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
           "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "dev": true,
           "requires": {
             "asap": "^2.0.0",
@@ -6346,8 +6438,9 @@
           }
         },
         "dot-prop": {
-          "version": "4.2.0",
-          "bundled": true,
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
           "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
@@ -6355,17 +6448,20 @@
         },
         "dotenv": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
           "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
           "dev": true
         },
         "duplexify": {
           "version": "3.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+          "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.0.0",
@@ -6376,7 +6472,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -6390,7 +6487,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -6400,7 +6498,8 @@
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6410,17 +6509,20 @@
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "encoding": {
           "version": "0.1.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "dev": true,
           "requires": {
             "iconv-lite": "~0.4.13"
@@ -6428,7 +6530,8 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -6436,17 +6539,20 @@
         },
         "env-paths": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
           "dev": true
         },
         "err-code": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
           "dev": true
         },
         "errno": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+          "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
           "dev": true,
           "requires": {
             "prr": "~1.0.1"
@@ -6454,7 +6560,8 @@
         },
         "es-abstract": {
           "version": "1.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+          "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.1.1",
@@ -6466,7 +6573,8 @@
         },
         "es-to-primitive": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
           "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
@@ -6476,12 +6584,14 @@
         },
         "es6-promise": {
           "version": "4.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
           "dev": true
         },
         "es6-promisify": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "dev": true,
           "requires": {
             "es6-promise": "^4.0.3"
@@ -6489,12 +6599,14 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -6508,44 +6620,52 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
           }
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
           "dev": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
           "dev": true
         },
         "figgy-pudding": {
           "version": "3.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+          "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
           "dev": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
+          "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
           "dev": true
         },
         "flush-write-stream": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+          "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -6554,7 +6674,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -6568,7 +6689,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -6578,12 +6700,14 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true
         },
         "form-data": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -6593,7 +6717,8 @@
         },
         "from2": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+          "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -6602,7 +6727,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -6616,7 +6742,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -6626,7 +6753,8 @@
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "dev": true,
           "requires": {
             "minipass": "^2.6.0"
@@ -6634,7 +6762,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -6645,7 +6774,8 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -6655,7 +6785,8 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -6666,12 +6797,14 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             },
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -6685,7 +6818,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -6695,17 +6829,20 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
           "dev": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -6720,12 +6857,14 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -6737,12 +6876,14 @@
         },
         "genfun": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+          "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
           "dev": true
         },
         "gentle-fs": {
           "version": "2.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.3.1.tgz",
+          "integrity": "sha512-OlwBBwqCFPcjm33rF2BjW+Pr6/ll2741l+xooiwTCeaX2CA1ZuclavyMBe0/KlR21/XGsgY6hzEQZ15BdNa13Q==",
           "dev": true,
           "requires": {
             "aproba": "^1.1.2",
@@ -6760,24 +6901,28 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             }
           }
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
         "get-stream": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -6785,7 +6930,8 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -6793,7 +6939,8 @@
         },
         "glob": {
           "version": "7.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -6806,7 +6953,8 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "dev": true,
           "requires": {
             "ini": "^1.3.4"
@@ -6814,7 +6962,8 @@
         },
         "got": {
           "version": "6.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
             "create-error-class": "^3.0.0",
@@ -6832,24 +6981,28 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
           "dev": true
         },
         "har-validator": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
           "dev": true,
           "requires": {
             "ajv": "^5.3.0",
@@ -6858,7 +7011,8 @@
         },
         "has": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
@@ -6866,32 +7020,38 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "has-symbols": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+          "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
           "dev": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
           "dev": true
         },
         "http-proxy-agent": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
           "dev": true,
           "requires": {
             "agent-base": "4",
@@ -6900,7 +7060,8 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -6910,7 +7071,8 @@
         },
         "https-proxy-agent": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
           "dev": true,
           "requires": {
             "agent-base": "^4.3.0",
@@ -6919,7 +7081,8 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
           "dev": true,
           "requires": {
             "ms": "^2.0.0"
@@ -6927,7 +7090,8 @@
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -6935,12 +7099,14 @@
         },
         "iferr": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
+          "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
           "dev": true
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -6948,22 +7114,26 @@
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+          "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -6972,17 +7142,20 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true
         },
         "init-package-json": {
           "version": "1.10.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+          "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -6997,22 +7170,26 @@
         },
         "ip": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
           "dev": true
         },
         "ip-regex": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
           "dev": true
         },
         "is-callable": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
           "dev": true
         },
         "is-ci": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "dev": true,
           "requires": {
             "ci-info": "^1.5.0"
@@ -7020,14 +7197,16 @@
           "dependencies": {
             "ci-info": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+              "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
               "dev": true
             }
           }
         },
         "is-cidr": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-3.0.0.tgz",
+          "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
           "dev": true,
           "requires": {
             "cidr-regex": "^2.0.10"
@@ -7035,12 +7214,14 @@
         },
         "is-date-object": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -7048,7 +7229,8 @@
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "dev": true,
           "requires": {
             "global-dirs": "^0.1.0",
@@ -7057,17 +7239,20 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "requires": {
             "path-is-inside": "^1.0.1"
@@ -7075,12 +7260,14 @@
         },
         "is-redirect": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
           "dev": true
         },
         "is-regex": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
           "dev": true,
           "requires": {
             "has": "^1.0.1"
@@ -7088,17 +7275,20 @@
         },
         "is-retry-allowed": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-symbol": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
           "dev": true,
           "requires": {
             "has-symbols": "^1.0.0"
@@ -7106,58 +7296,69 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -7168,7 +7369,8 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "dev": true,
           "requires": {
             "package-json": "^4.0.0"
@@ -7176,12 +7378,14 @@
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
           "dev": true
         },
         "libcipm": {
           "version": "4.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.8.tgz",
+          "integrity": "sha512-IN3hh2yDJQtZZ5paSV4fbvJg4aHxCCg5tcZID/dSVlTuUiWktsgaldVljJv6Z5OUlYspx6xQkbR0efNodnIrOA==",
           "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -7203,7 +7407,8 @@
         },
         "libnpm": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-3.0.1.tgz",
+          "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
           "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -7230,7 +7435,8 @@
         },
         "libnpmaccess": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.2.tgz",
+          "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -7241,7 +7447,8 @@
         },
         "libnpmconfig": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+          "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -7251,7 +7458,8 @@
           "dependencies": {
             "find-up": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "dev": true,
               "requires": {
                 "locate-path": "^3.0.0"
@@ -7259,7 +7467,8 @@
             },
             "locate-path": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "dev": true,
               "requires": {
                 "p-locate": "^3.0.0",
@@ -7268,7 +7477,8 @@
             },
             "p-limit": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+              "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
               "dev": true,
               "requires": {
                 "p-try": "^2.0.0"
@@ -7276,7 +7486,8 @@
             },
             "p-locate": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "dev": true,
               "requires": {
                 "p-limit": "^2.0.0"
@@ -7284,14 +7495,16 @@
             },
             "p-try": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
               "dev": true
             }
           }
         },
         "libnpmhook": {
           "version": "5.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.3.tgz",
+          "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -7302,7 +7515,8 @@
         },
         "libnpmorg": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.1.tgz",
+          "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -7313,7 +7527,8 @@
         },
         "libnpmpublish": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.2.tgz",
+          "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -7329,7 +7544,8 @@
         },
         "libnpmsearch": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.2.tgz",
+          "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -7339,7 +7555,8 @@
         },
         "libnpmteam": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.2.tgz",
+          "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -7350,7 +7567,8 @@
         },
         "libnpx": {
           "version": "10.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.4.tgz",
+          "integrity": "sha512-BPc0D1cOjBeS8VIBKUu5F80s6njm0wbVt7CsGMrIcJ+SI7pi7V0uVPGpEMH9H5L8csOcclTxAXFE2VAsJXUhfA==",
           "dev": true,
           "requires": {
             "dotenv": "^5.0.1",
@@ -7365,7 +7583,8 @@
         },
         "lock-verify": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.1.0.tgz",
+          "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
           "dev": true,
           "requires": {
             "npm-package-arg": "^6.1.0",
@@ -7374,7 +7593,8 @@
         },
         "lockfile": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+          "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
           "dev": true,
           "requires": {
             "signal-exit": "^3.0.2"
@@ -7382,12 +7602,14 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
           "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "dev": true,
           "requires": {
             "lodash._createset": "~4.0.0",
@@ -7396,17 +7618,20 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
@@ -7414,52 +7639,62 @@
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+          "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
           "dev": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
           "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
           "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
           "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
           "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
           "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
           "dev": true
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
           "dev": true
         },
         "lru-cache": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
             "yallist": "^3.0.2"
@@ -7467,7 +7702,8 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
             "pify": "^3.0.0"
@@ -7475,7 +7711,8 @@
         },
         "make-fetch-happen": {
           "version": "5.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
+          "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
           "dev": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
@@ -7492,18 +7729,21 @@
           }
         },
         "meant": {
-          "version": "1.0.1",
-          "bundled": true,
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.2.tgz",
+          "integrity": "sha512-KN+1uowN/NK+sT/Lzx7WSGIj2u+3xe5n2LbwObfjOhPZiA+cCfCm6idVl0RkEfjThkw5XJ96CyRcanq6GmKtUg==",
           "dev": true
         },
         "mime-db": {
           "version": "1.35.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.19",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
           "dev": true,
           "requires": {
             "mime-db": "~1.35.0"
@@ -7511,15 +7751,23 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
         "minizlib": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "dev": true,
           "requires": {
             "minipass": "^2.9.0"
@@ -7527,7 +7775,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -7538,7 +7787,8 @@
         },
         "mississippi": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "dev": true,
           "requires": {
             "concat-stream": "^1.5.0",
@@ -7555,7 +7805,8 @@
         },
         "mkdirp": {
           "version": "0.5.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -7563,14 +7814,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "dev": true,
           "requires": {
             "aproba": "^1.1.1",
@@ -7583,24 +7836,28 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             }
           }
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "dev": true
         },
         "node-fetch-npm": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+          "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
           "dev": true,
           "requires": {
             "encoding": "^0.1.11",
@@ -7610,7 +7867,8 @@
         },
         "node-gyp": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
+          "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
@@ -7628,7 +7886,8 @@
         },
         "nopt": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
           "dev": true,
           "requires": {
             "abbrev": "1",
@@ -7637,7 +7896,8 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -7648,7 +7908,8 @@
           "dependencies": {
             "resolve": {
               "version": "1.10.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+              "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
               "dev": true,
               "requires": {
                 "path-parse": "^1.0.6"
@@ -7658,7 +7919,8 @@
         },
         "npm-audit-report": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.3.tgz",
+          "integrity": "sha512-8nH/JjsFfAWMvn474HB9mpmMjrnKb1Hx/oTAdjv4PT9iZBvBxiZ+wtDUapHCJwLqYGQVPaAfs+vL5+5k9QndXw==",
           "dev": true,
           "requires": {
             "cli-table3": "^0.5.0",
@@ -7667,7 +7929,8 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "dev": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
@@ -7675,12 +7938,14 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "dev": true
         },
         "npm-install-checks": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.2.tgz",
+          "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
           "dev": true,
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
@@ -7688,7 +7953,8 @@
         },
         "npm-lifecycle": {
           "version": "3.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
+          "integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
           "dev": true,
           "requires": {
             "byline": "^5.0.0",
@@ -7703,17 +7969,20 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
+          "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
           "dev": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "dev": true
         },
         "npm-package-arg": {
           "version": "6.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+          "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.7.1",
@@ -7724,7 +7993,8 @@
         },
         "npm-packlist": {
           "version": "1.4.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+          "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
           "dev": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -7734,7 +8004,8 @@
         },
         "npm-pick-manifest": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
+          "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -7744,7 +8015,8 @@
         },
         "npm-profile": {
           "version": "4.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.4.tgz",
+          "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
           "dev": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
@@ -7753,8 +8025,9 @@
           }
         },
         "npm-registry-fetch": {
-          "version": "4.0.5",
-          "bundled": true,
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.7.tgz",
+          "integrity": "sha512-cny9v0+Mq6Tjz+e0erFAB+RYJ/AVGzkjnISiobqP8OWj9c9FLoZZu8/SPSKJWE17F1tk4018wfjV+ZbIbqC7fQ==",
           "dev": true,
           "requires": {
             "JSONStream": "^1.3.4",
@@ -7768,14 +8041,16 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
               "dev": true
             }
           }
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -7783,12 +8058,14 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+          "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
           "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -7799,27 +8076,32 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object-keys": {
           "version": "1.0.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+          "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
           "dev": true
         },
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+          "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
           "dev": true,
           "requires": {
             "define-properties": "^1.1.2",
@@ -7828,7 +8110,8 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -7836,22 +8119,26 @@
         },
         "opener": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+          "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
           "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -7860,12 +8147,14 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "dev": true,
           "requires": {
             "got": "^6.7.1",
@@ -7876,7 +8165,8 @@
         },
         "pacote": {
           "version": "9.5.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.12.tgz",
+          "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
@@ -7913,7 +8203,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -7924,7 +8215,8 @@
         },
         "parallel-transform": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+          "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
           "dev": true,
           "requires": {
             "cyclist": "~0.2.2",
@@ -7934,7 +8226,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -7948,7 +8241,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -7958,57 +8252,68 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
           "dev": true
         },
         "promise-retry": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+          "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
           "dev": true,
           "requires": {
             "err-code": "^1.0.0",
@@ -8017,14 +8322,16 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
               "dev": true
             }
           }
         },
         "promzard": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+          "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
           "dev": true,
           "requires": {
             "read": "1"
@@ -8032,12 +8339,14 @@
         },
         "proto-list": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+          "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
           "dev": true
         },
         "protoduck": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+          "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
           "dev": true,
           "requires": {
             "genfun": "^5.0.0"
@@ -8045,22 +8354,26 @@
         },
         "prr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "psl": {
           "version": "1.1.29",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+          "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -8069,7 +8382,8 @@
         },
         "pumpify": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "dev": true,
           "requires": {
             "duplexify": "^3.6.0",
@@ -8079,7 +8393,8 @@
           "dependencies": {
             "pump": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
               "dev": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
@@ -8090,22 +8405,26 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+          "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
           "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         },
         "query-string": {
           "version": "6.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
+          "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
           "dev": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
@@ -8115,30 +8434,26 @@
         },
         "qw": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
+          "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
           "dev": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.5",
-              "bundled": true,
-              "dev": true
-            }
           }
         },
         "read": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
@@ -8146,7 +8461,8 @@
         },
         "read-cmd-shim": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
+          "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -8154,7 +8470,8 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -8168,7 +8485,8 @@
         },
         "read-package-json": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
+          "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -8180,7 +8498,8 @@
         },
         "read-package-tree": {
           "version": "5.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+          "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
           "dev": true,
           "requires": {
             "read-package-json": "^2.0.0",
@@ -8190,7 +8509,8 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -8200,7 +8520,8 @@
         },
         "readdir-scoped-modules": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+          "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -8211,7 +8532,8 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "dev": true,
           "requires": {
             "rc": "^1.1.6",
@@ -8220,7 +8542,8 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "dev": true,
           "requires": {
             "rc": "^1.0.1"
@@ -8228,7 +8551,8 @@
         },
         "request": {
           "version": "2.88.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -8255,27 +8579,32 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "retry": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
           "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -8283,7 +8612,8 @@
         },
         "run-queue": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+          "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
           "dev": true,
           "requires": {
             "aproba": "^1.1.1"
@@ -8291,29 +8621,34 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             }
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "dev": true,
           "requires": {
             "semver": "^5.0.3"
@@ -8321,12 +8656,14 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "sha": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
+          "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -8334,7 +8671,8 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -8342,27 +8680,32 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "smart-buffer": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+          "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
           "dev": true
         },
         "socks": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+          "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
           "dev": true,
           "requires": {
             "ip": "1.1.5",
@@ -8371,7 +8714,8 @@
         },
         "socks-proxy-agent": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+          "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
           "dev": true,
           "requires": {
             "agent-base": "~4.2.1",
@@ -8380,7 +8724,8 @@
           "dependencies": {
             "agent-base": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+              "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
               "dev": true,
               "requires": {
                 "es6-promisify": "^5.0.0"
@@ -8390,12 +8735,14 @@
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
           "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "dev": true,
           "requires": {
             "from2": "^1.3.0",
@@ -8404,7 +8751,8 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "dev": true,
               "requires": {
                 "inherits": "~2.0.1",
@@ -8413,12 +8761,14 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
               "dev": true
             },
             "readable-stream": {
               "version": "1.1.14",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -8429,14 +8779,16 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "dev": true
             }
           }
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -8445,12 +8797,14 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -8459,17 +8813,20 @@
         },
         "spdx-license-ids": {
           "version": "3.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+          "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
           "dev": true
         },
         "split-on-first": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+          "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
           "dev": true
         },
         "sshpk": {
           "version": "1.14.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+          "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
           "dev": true,
           "requires": {
             "asn1": "~0.2.3",
@@ -8485,7 +8842,8 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -8493,7 +8851,8 @@
         },
         "stream-each": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+          "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -8502,7 +8861,8 @@
         },
         "stream-iterate": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+          "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
           "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
@@ -8511,7 +8871,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -8525,7 +8886,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -8535,17 +8897,20 @@
         },
         "stream-shift": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
           "dev": true
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -8554,17 +8919,20 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -8574,7 +8942,8 @@
         },
         "string_decoder": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -8582,19 +8951,22 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
               "dev": true
             }
           }
         },
         "stringify-package": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
+          "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -8602,17 +8974,20 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -8620,7 +8995,8 @@
         },
         "tar": {
           "version": "4.4.13",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "dev": true,
           "requires": {
             "chownr": "^1.1.1",
@@ -8634,7 +9010,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -8645,7 +9022,8 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "dev": true,
           "requires": {
             "execa": "^0.7.0"
@@ -8653,17 +9031,20 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
           "dev": true
         },
         "through": {
           "version": "2.3.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
           "dev": true
         },
         "through2": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
@@ -8672,7 +9053,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -8686,7 +9068,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -8696,17 +9079,20 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "dev": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
+          "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
           "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "dev": true,
           "requires": {
             "psl": "^1.1.24",
@@ -8715,7 +9101,8 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -8723,28 +9110,33 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "dev": true
         },
         "unique-filename": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
           "dev": true,
           "requires": {
             "unique-slug": "^2.0.0"
@@ -8752,7 +9144,8 @@
         },
         "unique-slug": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+          "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
@@ -8760,7 +9153,8 @@
         },
         "unique-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "dev": true,
           "requires": {
             "crypto-random-string": "^1.0.0"
@@ -8768,17 +9162,20 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
           "dev": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "dev": true
         },
         "update-notifier": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
           "dev": true,
           "requires": {
             "boxen": "^1.2.1",
@@ -8795,7 +9192,8 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
             "prepend-http": "^1.0.1"
@@ -8803,17 +9201,20 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "util-extend": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+          "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
           "dev": true
         },
         "util-promisify": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
+          "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
           "dev": true,
           "requires": {
             "object.getownpropertydescriptors": "^2.0.3"
@@ -8821,12 +9222,14 @@
         },
         "uuid": {
           "version": "3.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -8835,7 +9238,8 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "dev": true,
           "requires": {
             "builtins": "^1.0.3"
@@ -8843,7 +9247,8 @@
         },
         "verror": {
           "version": "1.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -8853,7 +9258,8 @@
         },
         "wcwidth": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+          "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
           "dev": true,
           "requires": {
             "defaults": "^1.0.3"
@@ -8861,7 +9267,8 @@
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -8869,12 +9276,14 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "requires": {
             "string-width": "^1.0.2"
@@ -8882,7 +9291,8 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -8894,7 +9304,8 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
           "dev": true,
           "requires": {
             "string-width": "^2.1.1"
@@ -8902,7 +9313,8 @@
         },
         "worker-farm": {
           "version": "1.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+          "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
           "dev": true,
           "requires": {
             "errno": "~0.1.7"
@@ -8910,7 +9322,8 @@
         },
         "wrap-ansi": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
@@ -8920,17 +9333,20 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "string-width": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "dev": true,
               "requires": {
                 "emoji-regex": "^7.0.1",
@@ -8940,7 +9356,8 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
@@ -8950,12 +9367,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -8965,27 +9384,32 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "dev": true
         },
         "xtend": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         },
         "yargs": {
           "version": "14.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
           "dev": true,
           "requires": {
             "cliui": "^5.0.0",
@@ -9003,12 +9427,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "dev": true
             },
             "find-up": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "dev": true,
               "requires": {
                 "locate-path": "^3.0.0"
@@ -9016,12 +9442,14 @@
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "locate-path": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "dev": true,
               "requires": {
                 "p-locate": "^3.0.0",
@@ -9030,7 +9458,8 @@
             },
             "p-limit": {
               "version": "2.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
               "dev": true,
               "requires": {
                 "p-try": "^2.0.0"
@@ -9038,7 +9467,8 @@
             },
             "p-locate": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "dev": true,
               "requires": {
                 "p-limit": "^2.0.0"
@@ -9046,12 +9476,14 @@
             },
             "p-try": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
               "dev": true
             },
             "string-width": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "dev": true,
               "requires": {
                 "emoji-regex": "^7.0.1",
@@ -9061,7 +9493,8 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
@@ -9071,7 +9504,8 @@
         },
         "yargs-parser": {
           "version": "15.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -9080,7 +9514,8 @@
           "dependencies": {
             "camelcase": {
               "version": "5.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
               "dev": true
             }
           }
@@ -9545,12 +9980,6 @@
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -9653,9 +10082,9 @@
       "dev": true
     },
     "registry-auth-token": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
-      "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
+      "integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
       "dev": true,
       "requires": {
         "rc": "^1.2.8"
@@ -9848,12 +10277,12 @@
           }
         },
         "hosted-git-info": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.4.tgz",
-          "integrity": "sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==",
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
+          "integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
           "dev": true,
           "requires": {
-            "lru-cache": "^5.1.1"
+            "lru-cache": "^6.0.0"
           }
         },
         "locate-path": {
@@ -9890,14 +10319,14 @@
           "dev": true
         },
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -9943,19 +10372,13 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
         }
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
       "dev": true
     },
     "semver-compare": {
@@ -9971,6 +10394,14 @@
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "semver-regex": {
@@ -10561,9 +10992,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -10780,9 +11211,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.4.tgz",
+      "integrity": "sha512-kBFT3U4Dcj4/pJ52vfjCSfyLyvG9VYYuGYPmrPvAxRw/i7xHiT4VvCev+uiEMcEEiu6UNB6KgWmGtSUYIWScbw==",
       "dev": true,
       "optional": true
     },
@@ -10932,9 +11363,9 @@
       "dev": true
     },
     "windows-release": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
-      "integrity": "sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.3.tgz",
+      "integrity": "sha512-OSOGH1QYiW5yVor9TtmXKQvt2vjQqbYS+DqmsZw+r7xDwLXEeT3JGW0ZppFmHx4diyXmxt238KFR3N9jzevBRg==",
       "dev": true,
       "requires": {
         "execa": "^1.0.0"
@@ -11117,9 +11548,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yaml": {


### PR DESCRIPTION
In order to pick up a fix for the [dot-prop vulnerability](https://github.com/advisories/GHSA-ff7x-qrg7-qggm), I had to force-update `conventional-changelog-angular` to version 5.0.11. This updates various sub-dependencies to pick up the latest versions by deleting `package-lock` and regenerating it via `npm i`.