### PR TITLE
feat: disable `import/prefer-default-export`

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,5 +44,6 @@ module.exports = {
         optionalDependencies: false,
       },
     ],
+    'import/prefer-default-export': 'off',
   },
 };


### PR DESCRIPTION
In a number of places in our code base we disable this
"prefer-default-export" rule. We often do this because the context of
the export doesn't make sense as a "default export" (e.g. exporting a
function from a module called `utils`).

Since this rule prevents us from using named exports in contexts where
it makes sense to do so this commit disables this rule.