### PR TITLE
Add rule "curly" enforcing curly braces

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ module.exports = {
       { blankLine: 'always', prev: '*', next: 'return' },
     ],
 
+    // Ensure control structures use curly braces rather than inline for single statements
+    curly: 'error',
+
     // Allow underscore dangles for private members (e.g. this._foo)
     'no-underscore-dangle': ['error', { allowAfterThis: true }],
 


### PR DESCRIPTION
Example of invalid code:

```js
if (foo) return 'bar';
```

Example of valid code:
```js
if (foo) {
  return 'bar';
}
```
