### PR TITLE
Expand curly rules to "all", previously "multiline" from airbnb

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     ],
 
     // Ensure control structures use curly braces rather than inline for single statements
-    curly: 'error',
+    curly: ['error', 'all'], // multiline is the default from airbnb
 
     // Allow underscore dangles for private members (e.g. this._foo)
     'no-underscore-dangle': ['error', { allowAfterThis: true }],


### PR DESCRIPTION
The multiline option is set by airbnb's rules which we extend. It allows some instances to pass, like this:

```
if (foo == 'bar') return 'baz';
```

Enforcing "all" means curly braces are always required for control structures. Valid example:

```diff
- if (foo == 'bar') return 'baz';
+ if (foo == 'bar') {
+   return 'baz';
+ }
```
