### PR TITLE
feat: Add func-style rule - GFE-127

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@ module.exports = {
     // Prefer it() over test(), unless outside a describe() block
     'jest/consistent-test-it': 'error',
 
+    // Prefer const foo = () => {...} over function foo() {...} (default: "expression")
+    'func-style': 'error',
+
     'import/no-extraneous-dependencies': [
       'error',
       {


### PR DESCRIPTION
Enabling a linting rule that makes this code invalid:

```js
function foo() {
  ...
}
```

Now should be:

```js
const foo = () => {
  ...
}
```

Rule: https://eslint.org/docs/latest/rules/func-style#expression
