### PR TITLE
fix: prevent func-names from enforcing names on generators, conflicts with func-style

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = {
 
     // Prefer const foo = () => {...} over function foo() {...} (default: "expression")
     'func-style': 'error',
+    'func-names': ['error', 'always', { generators: 'as-needed' }],
 
     'import/no-extraneous-dependencies': [
       'error',


### PR DESCRIPTION
With `func-style` enabled, this becomes invalid:

```js
const fetchPropertyIdList = function* () {
# ESLint: Unexpected unnamed generator function.(func-names)
```

This change makes these code variations valid:

```js
const fetchPropertyIdList = function* () {

trackedPropertiesGET.createSaga(function* doTrackedPropertiesGET() {
```
