### PR TITLE
fix: do not require extensions in import paths for js and ts files

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,5 +56,16 @@ module.exports = {
       },
     ],
     'import/prefer-default-export': 'off',
+
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        js: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never',
+      },
+    ],
   },
 };


### PR DESCRIPTION
Fixes errors like this:

```
# ESLint: Missing file extension "ts" for "./getDatesDiff"(import/extensions)
import { getDatesDiff } from './getDatesDiff';
```
